### PR TITLE
Add React Native mobile client with shared Tailwind design system

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,25 @@ In India, mental health is often not taken seriously. Fear of judgment from soci
 ## AI session
 <img src="./public/images/CurieAIsession.jpg">
 
+
+## Mobile application (React Native)
+
+A React Native mobile client now lives under `mobile/`. It reuses the CureZ authentication and session flows with a
+native navigation stack and a shared design system that is controlled from `mobile/tailwind.config.js`.
+
+### Getting started
+
+```bash
+cd mobile
+npm install
+npm run start
+```
+
+Set the following environment variables before running the Expo dev server:
+
+- `EXPO_PUBLIC_FIREBASE_API_KEY` – same value used on the web client.
+- `EXPO_PUBLIC_API_BASE_URL` – URL of the deployed CureZ backend (for example `https://your-domain.example`).
+
+The mobile session screen currently falls back to an on-device response if the `/api/mobile-session` endpoint is not
+available. Hook this endpoint up to the existing WebSocket/audio workflow when you are ready to surface the full
+experience on mobile.

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from "react"
+import * as SplashScreen from "expo-splash-screen"
+import { StatusBar } from "expo-status-bar"
+import { ThemeProvider, useTheme } from "@/contexts/ThemeContext"
+import { AuthProvider } from "@/contexts/AuthContext"
+import { AppNavigator } from "@/navigation/AppNavigator"
+
+SplashScreen.preventAutoHideAsync().catch(() => {
+  /* ignore */
+})
+
+const RootNavigation: React.FC = () => {
+  const { scheme } = useTheme()
+
+  useEffect(() => {
+    SplashScreen.hideAsync().catch(() => {
+      /* ignore */
+    })
+  }, [])
+
+  return (
+    <>
+      <AppNavigator />
+      <StatusBar style={scheme === "dark" ? "light" : "dark"} />
+    </>
+  )
+}
+
+export default function App() {
+  return (
+    <ThemeProvider>
+      <AuthProvider>
+        <RootNavigation />
+      </AuthProvider>
+    </ThemeProvider>
+  )
+}

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,27 @@
+{
+  "expo": {
+    "name": "Youth Mental Wellness",
+    "slug": "youth-mental-wellness-mobile",
+    "version": "0.1.0",
+    "orientation": "portrait",
+    "assetBundlePatterns": ["**/*"],
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "backgroundColor": "#0F172A"
+      }
+    },
+    "web": {
+      "bundler": "metro",
+      "output": "static"
+    },
+    "plugins": ["nativewind/babel"],
+    "extra": {
+      "eas": {
+        "projectId": "00000000-0000-0000-0000-000000000000"
+      }
+    }
+  }
+}

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true)
+  return {
+    presets: ["babel-preset-expo"],
+    plugins: ["nativewind/babel"],
+  }
+}

--- a/mobile/nativewind.d.ts
+++ b/mobile/nativewind.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="nativewind/types" />

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "youth-mental-wellness-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web",
+    "lint": "expo lint"
+  },
+  "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.21.0",
+    "@react-navigation/native": "^6.1.11",
+    "@react-navigation/native-stack": "^6.9.20",
+    "expo": "~50.0.8",
+    "expo-constants": "~15.4.5",
+    "expo-font": "~11.10.3",
+    "expo-linking": "~6.2.2",
+    "expo-splash-screen": "~0.26.4",
+    "expo-status-bar": "~1.7.4",
+    "nativewind": "^2.0.11",
+    "react": "18.2.0",
+    "react-native": "0.73.6",
+    "react-native-safe-area-context": "4.8.2",
+    "react-native-screens": "~3.29.0",
+    "tailwindcss": "^3.3.6",
+    "clsx": "^2.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.0",
+    "@types/react": "18.2.31",
+    "@types/react-native": "0.73.0",
+    "typescript": "5.3.3"
+  }
+}

--- a/mobile/src/components/Button.tsx
+++ b/mobile/src/components/Button.tsx
@@ -1,0 +1,48 @@
+import { Pressable, Text, type PressableProps } from "react-native"
+import clsx from "clsx"
+
+export type ButtonVariant = "primary" | "secondary" | "outline" | "ghost" | "danger"
+
+type Props = PressableProps & {
+  title: string
+  variant?: ButtonVariant
+  fullWidth?: boolean
+  className?: string
+}
+
+const variantStyles: Record<ButtonVariant, string> = {
+  primary:
+    "bg-brand text-brand-foreground dark:bg-brand-dark dark:text-brand-dark-foreground",
+  secondary: "bg-accent text-surface-foreground",
+  outline:
+    "border border-surface-strong text-surface-foreground dark:border-surface-dark-strong",
+  ghost: "bg-transparent text-surface-foreground",
+  danger: "bg-feedback-danger text-white",
+}
+
+export const Button = ({
+  title,
+  variant = "primary",
+  fullWidth,
+  style,
+  className,
+  ...pressableProps
+}: Props) => {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      {...pressableProps}
+      className={clsx(
+        "px-4 py-3 rounded-xl items-center justify-center",
+        fullWidth && "w-full",
+        variantStyles[variant],
+        className
+      )}
+      style={style}
+    >
+      <Text className="font-heading text-base" selectable={false}>
+        {title}
+      </Text>
+    </Pressable>
+  )
+}

--- a/mobile/src/components/Card.tsx
+++ b/mobile/src/components/Card.tsx
@@ -1,0 +1,48 @@
+import { ReactNode } from "react"
+import { View, Text } from "react-native"
+import clsx from "clsx"
+
+type CardProps = {
+  children: ReactNode
+  className?: string
+}
+
+type CardHeaderProps = {
+  title: string
+  subtitle?: string
+}
+
+export const Card: React.FC<CardProps> = ({ children, className }) => {
+  return (
+    <View
+      className={clsx(
+        "bg-surface rounded-3xl shadow-elevated p-6 gap-4 dark:bg-surface-dark",
+        className
+      )}
+    >
+      {children}
+    </View>
+  )
+}
+
+export const CardHeader: React.FC<CardHeaderProps> = ({ title, subtitle }) => {
+  return (
+    <View>
+      <Text className="text-2xl font-heading text-surface-foreground dark:text-surface-dark-foreground">
+        {title}
+      </Text>
+      {subtitle ? (
+        <Text className="mt-1 text-base text-surface-foreground/70 dark:text-surface-dark-foreground/70">
+          {subtitle}
+        </Text>
+      ) : null}
+    </View>
+  )
+}
+
+export const CardContent: React.FC<{ children: ReactNode; className?: string }> = ({
+  children,
+  className,
+}) => {
+  return <View className={clsx("gap-3", className)}>{children}</View>
+}

--- a/mobile/src/components/TextField.tsx
+++ b/mobile/src/components/TextField.tsx
@@ -1,0 +1,34 @@
+import { forwardRef } from "react"
+import { TextInput, TextInputProps, View, Text } from "react-native"
+import clsx from "clsx"
+
+type Props = TextInputProps & {
+  label?: string
+  error?: string
+}
+
+export const TextField = forwardRef<TextInput, Props>(
+  ({ label, error, className, ...props }, ref) => {
+    return (
+      <View className="gap-2">
+        {label ? (
+          <Text className="text-sm font-heading text-surface-foreground dark:text-surface-dark-foreground">
+            {label}
+          </Text>
+        ) : null}
+        <TextInput
+          ref={ref}
+          placeholderTextColor="#94A3B8"
+          className={clsx(
+            "rounded-2xl border border-surface-strong dark:border-surface-dark-strong px-4 py-3 text-base text-surface-foreground dark:text-surface-dark-foreground bg-white dark:bg-surface-dark-muted",
+            className
+          )}
+          {...props}
+        />
+        {error ? <Text className="text-sm text-feedback-danger">{error}</Text> : null}
+      </View>
+    )
+  }
+)
+
+TextField.displayName = "TextField"

--- a/mobile/src/components/ThemeToggle.tsx
+++ b/mobile/src/components/ThemeToggle.tsx
@@ -1,0 +1,20 @@
+import { View, Text } from "react-native"
+import { Button } from "@/components/Button"
+import { useTheme } from "@/contexts/ThemeContext"
+
+export const ThemeToggle = () => {
+  const { scheme, toggleTheme } = useTheme()
+
+  return (
+    <View className="flex-row items-center justify-between">
+      <Text className="text-base font-heading text-surface-foreground dark:text-surface-dark-foreground">
+        {scheme === "light" ? "Light" : "Dark"} Mode
+      </Text>
+      <Button
+        title={scheme === "light" ? "Enable Dark" : "Enable Light"}
+        variant="outline"
+        onPress={toggleTheme}
+      />
+    </View>
+  )
+}

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -1,0 +1,166 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react"
+import AsyncStorage from "@react-native-async-storage/async-storage"
+import {
+  AuthUser,
+  SignupForm,
+  getCurrentUser,
+  login as loginRequest,
+  signup as signupRequest,
+  requestPasswordReset,
+  updateProfile,
+} from "@/services/auth"
+
+export type AuthStatus = "idle" | "loading" | "authenticated" | "error"
+
+type AuthContextValue = {
+  user: AuthUser | null
+  status: AuthStatus
+  login: (email: string, password: string) => Promise<void>
+  signup: (form: SignupForm) => Promise<void>
+  logout: () => Promise<void>
+  refreshProfile: () => Promise<void>
+  sendPasswordReset: (email: string) => Promise<void>
+  updateUserProfile: (profile: Partial<AuthUser>) => Promise<void>
+  errorMessage?: string | null
+}
+
+const STORAGE_KEY = "@curez_current_user"
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+type AuthProviderProps = {
+  children: ReactNode
+}
+
+export const AuthProvider = ({ children }: AuthProviderProps) => {
+  const [user, setUser] = useState<AuthUser | null>(null)
+  const [status, setStatus] = useState<AuthStatus>("idle")
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    const loadUser = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(STORAGE_KEY)
+        if (stored) {
+          const parsed = JSON.parse(stored) as AuthUser
+          setUser(parsed)
+          setStatus("authenticated")
+          const fresh = await getCurrentUser(parsed.uid)
+          if (fresh) {
+            const merged = { ...parsed, ...fresh }
+            setUser(merged)
+            await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(merged))
+          }
+        } else {
+          setStatus("idle")
+        }
+      } catch (error) {
+        console.warn("Failed to restore stored user", error)
+        setStatus("idle")
+      }
+    }
+    loadUser()
+  }, [])
+
+  const persistUser = useCallback(async (value: AuthUser | null) => {
+    setUser(value)
+    if (value) {
+      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(value))
+    } else {
+      await AsyncStorage.removeItem(STORAGE_KEY)
+    }
+  }, [])
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      setStatus("loading")
+      setErrorMessage(null)
+      try {
+        const authenticated = await loginRequest(email, password)
+        await persistUser(authenticated)
+        setStatus("authenticated")
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unable to login"
+        setErrorMessage(message)
+        setStatus("error")
+        throw error
+      }
+    },
+    [persistUser]
+  )
+
+  const signup = useCallback(async (form: SignupForm) => {
+    setStatus("loading")
+    setErrorMessage(null)
+    try {
+      await signupRequest(form)
+      setStatus("idle")
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to sign up"
+      setErrorMessage(message)
+      setStatus("error")
+      throw error
+    }
+  }, [])
+
+  const logout = useCallback(async () => {
+    setStatus("idle")
+    setErrorMessage(null)
+    await persistUser(null)
+  }, [persistUser])
+
+  const refreshProfile = useCallback(async () => {
+    if (!user) return
+    const profile = await getCurrentUser(user.uid)
+    if (profile) {
+      const merged = { ...user, ...profile }
+      await persistUser(merged)
+    }
+  }, [persistUser, user])
+
+  const sendPasswordReset = useCallback(async (email: string) => {
+    await requestPasswordReset(email)
+  }, [])
+
+  const updateUserProfile = useCallback(
+    async (profile: Partial<AuthUser>) => {
+      if (!user) return
+      const updated = await updateProfile({ ...profile, uid: user.uid })
+      await persistUser({ ...user, ...updated })
+    },
+    [persistUser, user]
+  )
+
+  const value = useMemo(
+    () => ({
+      user,
+      status,
+      login,
+      signup,
+      logout,
+      refreshProfile,
+      sendPasswordReset,
+      updateUserProfile,
+      errorMessage,
+    }),
+    [user, status, login, signup, logout, refreshProfile, sendPasswordReset, updateUserProfile, errorMessage]
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export const useAuth = () => {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider")
+  }
+  return context
+}

--- a/mobile/src/contexts/ThemeContext.tsx
+++ b/mobile/src/contexts/ThemeContext.tsx
@@ -1,0 +1,93 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react"
+import { Appearance } from "react-native"
+import AsyncStorage from "@react-native-async-storage/async-storage"
+import { NativeWindStyleSheet } from "nativewind"
+
+type ThemeScheme = "light" | "dark"
+
+type ThemeContextValue = {
+  scheme: ThemeScheme
+  toggleTheme: () => void
+  setScheme: (scheme: ThemeScheme) => void
+}
+
+const STORAGE_KEY = "@curez_theme"
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+const resolveInitialScheme = async (): Promise<ThemeScheme> => {
+  try {
+    const stored = await AsyncStorage.getItem(STORAGE_KEY)
+    if (stored === "light" || stored === "dark") {
+      return stored
+    }
+  } catch (error) {
+    console.warn("Failed to load theme preference", error)
+  }
+  const system = Appearance.getColorScheme()
+  return system === "dark" ? "dark" : "light"
+}
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [scheme, setSchemeState] = useState<ThemeScheme>("light")
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    resolveInitialScheme().then((value) => {
+      setSchemeState(value)
+      NativeWindStyleSheet.setColorScheme(value)
+      setHydrated(true)
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!hydrated) return
+    const subscription = Appearance.addChangeListener(({ colorScheme }) => {
+      if (!colorScheme) return
+      setTheme(colorScheme === "dark" ? "dark" : "light")
+    })
+    return () => subscription.remove()
+  }, [hydrated])
+
+  const setTheme = (value: ThemeScheme) => {
+    setSchemeState(value)
+    NativeWindStyleSheet.setColorScheme(value)
+    AsyncStorage.setItem(STORAGE_KEY, value).catch((error) =>
+      console.warn("Failed to persist theme preference", error)
+    )
+  }
+
+  const toggleTheme = () => {
+    setTheme(scheme === "light" ? "dark" : "light")
+  }
+
+  const value = useMemo(
+    () => ({
+      scheme,
+      toggleTheme,
+      setScheme: setTheme,
+    }),
+    [scheme]
+  )
+
+  if (!hydrated) {
+    return null
+  }
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext)
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider")
+  }
+  return context
+}

--- a/mobile/src/hooks/useChatSession.ts
+++ b/mobile/src/hooks/useChatSession.ts
@@ -1,0 +1,66 @@
+import { useCallback, useMemo, useState } from "react"
+import { sendSessionMessage } from "@/services/session"
+import type { ChatMessage } from "@/services/session"
+
+const createMessage = (text: string, sender: "user" | "assistant"): ChatMessage => ({
+  id: `${sender}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  text,
+  sender,
+  createdAt: new Date().toISOString(),
+})
+
+export const useChatSession = (userId?: string) => {
+  const [messages, setMessages] = useState<ChatMessage[]>(() => [
+    createMessage(
+      "Hello! I'm CureZ, your AI mentor. Share how you're feeling today, and we'll work through it together.",
+      "assistant"
+    ),
+  ])
+  const [isSending, setIsSending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const sendTextMessage = useCallback(
+    async (text: string) => {
+      if (!text.trim()) {
+        return
+      }
+      const outgoing = createMessage(text.trim(), "user")
+      setMessages((prev) => [...prev, outgoing])
+      setIsSending(true)
+      setError(null)
+
+      try {
+        const reply = await sendSessionMessage(text.trim(), { userId })
+        setMessages((prev) => [...prev, createMessage(reply.reply, "assistant")])
+      } catch (caught) {
+        const message = caught instanceof Error ? caught.message : "Something went wrong"
+        setError(message)
+        setMessages((prev) => [
+          ...prev,
+          createMessage(
+            "I couldn't reach the live service right now, but I'm still here for you. Let's try again soon.",
+            "assistant"
+          ),
+        ])
+      } finally {
+        setIsSending(false)
+      }
+    },
+    [userId]
+  )
+
+  const contextValue = useMemo(
+    () => ({
+      messages,
+      isSending,
+      error,
+    }),
+    [messages, isSending, error]
+  )
+
+  return {
+    ...contextValue,
+    sendTextMessage,
+    clearError: () => setError(null),
+  }
+}

--- a/mobile/src/navigation/AppNavigator.tsx
+++ b/mobile/src/navigation/AppNavigator.tsx
@@ -1,0 +1,42 @@
+import { useMemo } from "react"
+import { NavigationContainer, DarkTheme, DefaultTheme } from "@react-navigation/native"
+import { createNativeStackNavigator } from "@react-navigation/native-stack"
+import { useTheme } from "@/contexts/ThemeContext"
+import { useAuth } from "@/contexts/AuthContext"
+import { LandingScreen } from "@/screens/LandingScreen"
+import { AuthScreen } from "@/screens/AuthScreen"
+import { DashboardScreen } from "@/screens/DashboardScreen"
+import { SessionScreen } from "@/screens/SessionScreen"
+
+export type RootStackParamList = {
+  Landing: undefined
+  Auth: undefined
+  Dashboard: undefined
+  Session: undefined
+}
+
+const Stack = createNativeStackNavigator<RootStackParamList>()
+
+export const AppNavigator: React.FC = () => {
+  const { scheme } = useTheme()
+  const { user } = useAuth()
+
+  const initialRoute = useMemo(() => (user ? "Dashboard" : "Landing"), [user])
+
+  return (
+    <NavigationContainer theme={scheme === "dark" ? DarkTheme : DefaultTheme}>
+      <Stack.Navigator
+        initialRouteName={initialRoute}
+        screenOptions={{
+          headerShown: false,
+          animation: "fade",
+        }}
+      >
+        <Stack.Screen name="Landing" component={LandingScreen} />
+        <Stack.Screen name="Auth" component={AuthScreen} />
+        <Stack.Screen name="Dashboard" component={DashboardScreen} />
+        <Stack.Screen name="Session" component={SessionScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  )
+}

--- a/mobile/src/screens/AuthScreen.tsx
+++ b/mobile/src/screens/AuthScreen.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react"
+import { Alert, ScrollView, Text, View } from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack"
+import { Button } from "@/components/Button"
+import { Card, CardContent, CardHeader } from "@/components/Card"
+import { TextField } from "@/components/TextField"
+import { useAuth } from "@/contexts/AuthContext"
+import { RootStackParamList } from "@/navigation/AppNavigator"
+
+export const AuthScreen: React.FC = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
+  const auth = useAuth()
+  const [mode, setMode] = useState<"login" | "signup">("login")
+  const [forgotPassword, setForgotPassword] = useState(false)
+
+  const [loginEmail, setLoginEmail] = useState("")
+  const [loginPassword, setLoginPassword] = useState("")
+
+  const [signupForm, setSignupForm] = useState({
+    email: "",
+    password: "",
+    name: "",
+    age: "",
+    gender: "",
+  })
+
+  const handleLogin = async () => {
+    if (!loginEmail || !loginPassword) {
+      Alert.alert("Missing information", "Enter your email and password to continue.")
+      return
+    }
+    try {
+      await auth.login(loginEmail, loginPassword)
+      navigation.reset({ index: 0, routes: [{ name: "Dashboard" }] })
+    } catch (error) {
+      Alert.alert("Login failed", auth.errorMessage || "Please try again later.")
+    }
+  }
+
+  const handleSignup = async () => {
+    if (!signupForm.email || !signupForm.password || !signupForm.name || !signupForm.age) {
+      Alert.alert("Missing information", "Please complete all fields to continue.")
+      return
+    }
+    try {
+      await auth.signup(signupForm)
+      Alert.alert(
+        "Verify your email",
+        "We sent a verification link to your inbox. Please verify your account before logging in."
+      )
+      setMode("login")
+      setLoginEmail(signupForm.email)
+      setSignupForm({ email: "", password: "", name: "", age: "", gender: "" })
+    } catch (error) {
+      Alert.alert("Signup failed", auth.errorMessage || "Please try again later.")
+    }
+  }
+
+  const handlePasswordReset = async () => {
+    if (!loginEmail) {
+      Alert.alert("Missing email", "Enter your registered email to receive a reset link.")
+      return
+    }
+    try {
+      await auth.sendPasswordReset(loginEmail)
+      Alert.alert("Reset email sent", "Check your inbox for password reset instructions.")
+      setForgotPassword(false)
+    } catch (error) {
+      Alert.alert("Unable to send reset email", auth.errorMessage || "Please try again later.")
+    }
+  }
+
+  return (
+    <ScrollView
+      className="flex-1 bg-surface dark:bg-surface-dark"
+      contentContainerStyle={{ padding: 24, flexGrow: 1, justifyContent: "center" }}
+    >
+      <Card className="gap-6">
+        <CardHeader
+          title="Welcome to CureZ"
+          subtitle="Your personalised wellbeing mentor, now on mobile"
+        />
+        <View className="flex-row bg-surface-muted dark:bg-surface-dark-muted rounded-2xl p-1">
+          <Button
+            title="Login"
+            variant={mode === "login" ? "primary" : "ghost"}
+            className="flex-1"
+            onPress={() => {
+              setMode("login")
+              setForgotPassword(false)
+            }}
+          />
+          <Button
+            title="Sign up"
+            variant={mode === "signup" ? "primary" : "ghost"}
+            className="flex-1"
+            onPress={() => setMode("signup")}
+          />
+        </View>
+        <CardContent>
+          {mode === "login" ? (
+            <View className="gap-4">
+              <TextField
+                label="Email"
+                keyboardType="email-address"
+                autoCapitalize="none"
+                value={loginEmail}
+                onChangeText={setLoginEmail}
+              />
+              {!forgotPassword ? (
+                <>
+                  <TextField
+                    label="Password"
+                    secureTextEntry
+                    value={loginPassword}
+                    onChangeText={setLoginPassword}
+                  />
+                  <Button
+                    title={auth.status === "loading" ? "Signing in..." : "Login"}
+                    onPress={handleLogin}
+                    fullWidth
+                  />
+                  <Button
+                    title="Forgot password?"
+                    variant="ghost"
+                    onPress={() => setForgotPassword(true)}
+                  />
+                </>
+              ) : (
+                <>
+                  <Text className="text-sm text-surface-foreground/80 dark:text-surface-dark-foreground/70">
+                    Enter your registered email address. We'll send a password reset link through Firebase.
+                  </Text>
+                  <Button title="Send reset link" onPress={handlePasswordReset} fullWidth />
+                  <Button
+                    title="Back to login"
+                    variant="ghost"
+                    onPress={() => setForgotPassword(false)}
+                  />
+                </>
+              )}
+            </View>
+          ) : (
+            <View className="gap-4">
+              <TextField label="Full name" value={signupForm.name} onChangeText={(name) => setSignupForm((prev) => ({ ...prev, name }))} />
+              <TextField
+                label="Age"
+                keyboardType="number-pad"
+                value={signupForm.age}
+                onChangeText={(age) => setSignupForm((prev) => ({ ...prev, age }))}
+              />
+              <TextField
+                label="Gender"
+                value={signupForm.gender}
+                onChangeText={(gender) => setSignupForm((prev) => ({ ...prev, gender }))}
+              />
+              <TextField
+                label="Email"
+                keyboardType="email-address"
+                autoCapitalize="none"
+                value={signupForm.email}
+                onChangeText={(email) => setSignupForm((prev) => ({ ...prev, email }))}
+              />
+              <TextField
+                label="Password"
+                secureTextEntry
+                value={signupForm.password}
+                onChangeText={(password) => setSignupForm((prev) => ({ ...prev, password }))}
+              />
+              <Button
+                title={auth.status === "loading" ? "Creating account..." : "Create account"}
+                onPress={handleSignup}
+                fullWidth
+              />
+            </View>
+          )}
+        </CardContent>
+        <Button title="Back" variant="ghost" onPress={() => navigation.goBack()} />
+      </Card>
+    </ScrollView>
+  )
+}

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -1,0 +1,101 @@
+import { useEffect } from "react"
+import { Alert, ScrollView, Text, View } from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack"
+import { Button } from "@/components/Button"
+import { Card, CardContent, CardHeader } from "@/components/Card"
+import { ThemeToggle } from "@/components/ThemeToggle"
+import { useAuth } from "@/contexts/AuthContext"
+import { RootStackParamList } from "@/navigation/AppNavigator"
+
+const wellnessHighlights = [
+  {
+    title: "Daily reflection",
+    body: "Take a 3-minute check-in to log your thoughts and emotions.",
+  },
+  {
+    title: "Guided breathing",
+    body: "Follow our paced breathing exercise whenever you need a reset.",
+  },
+  {
+    title: "Progress tracker",
+    body: "Visualise your streaks and celebrate your wins each week.",
+  },
+]
+
+export const DashboardScreen: React.FC = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
+  const { user, logout, refreshProfile } = useAuth()
+
+  useEffect(() => {
+    refreshProfile().catch(() => {
+      // non-blocking
+    })
+  }, [refreshProfile])
+
+  const handleLogout = async () => {
+    await logout()
+    navigation.reset({ index: 0, routes: [{ name: "Landing" }] })
+  }
+
+  return (
+    <ScrollView
+      className="flex-1 bg-surface dark:bg-surface-dark"
+      contentContainerStyle={{ padding: 24, paddingBottom: 56 }}
+    >
+      <View className="mt-12 gap-6">
+        <Text className="text-3xl font-display text-surface-foreground dark:text-surface-dark-foreground">
+          Hi {user?.name || "there"}
+        </Text>
+        <Text className="text-base text-surface-foreground/80 dark:text-surface-dark-foreground/80">
+          You're building a strong support routine. Jump back into your session or explore today's curated
+          exercises.
+        </Text>
+
+        <Card className="gap-4">
+          <CardHeader title="Quick actions" subtitle="Stay connected with your mentor" />
+          <CardContent className="gap-3">
+            <Button
+              title="Start a live session"
+              onPress={() => navigation.navigate("Session")}
+              fullWidth
+            />
+            <Button
+              title="Update profile"
+              variant="outline"
+              onPress={() => Alert.alert("Coming soon", "Profile editing will ship in the next sprint.")}
+              fullWidth
+            />
+            <Button title="Logout" variant="ghost" onPress={handleLogout} fullWidth />
+          </CardContent>
+        </Card>
+
+        <Card className="gap-4">
+          <CardHeader title="Design preferences" subtitle="Switch modes anytime" />
+          <CardContent>
+            <ThemeToggle />
+          </CardContent>
+        </Card>
+
+        <Card className="gap-4">
+          <CardHeader title="Wellness toolkit" subtitle="Highlights from the CureZ library" />
+          <CardContent className="gap-4">
+            {wellnessHighlights.map((item) => (
+              <View
+                key={item.title}
+                className="bg-surface-muted dark:bg-surface-dark-muted rounded-2xl p-4 gap-2"
+              >
+                <Text className="text-lg font-heading text-surface-foreground dark:text-surface-dark-foreground">
+                  {item.title}
+                </Text>
+                <Text className="text-sm leading-6 text-surface-foreground/70 dark:text-surface-dark-foreground/70">
+                  {item.body}
+                </Text>
+              </View>
+            ))}
+          </CardContent>
+        </Card>
+      </View>
+    </ScrollView>
+  )
+}

--- a/mobile/src/screens/LandingScreen.tsx
+++ b/mobile/src/screens/LandingScreen.tsx
@@ -1,0 +1,53 @@
+import { useCallback } from "react"
+import { View, Text, ScrollView, Image } from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack"
+import { Button } from "@/components/Button"
+import { ThemeToggle } from "@/components/ThemeToggle"
+import { RootStackParamList } from "@/navigation/AppNavigator"
+
+const HERO_URI =
+  "https://images.unsplash.com/photo-1527628173875-3c7bfd28ad78?auto=format&fit=crop&w=900&q=80"
+
+export const LandingScreen: React.FC = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
+
+  const handleBegin = useCallback(() => {
+    navigation.navigate("Auth")
+  }, [navigation])
+
+  return (
+    <ScrollView className="flex-1 bg-surface dark:bg-surface-dark" contentContainerStyle={{ padding: 24 }}>
+      <View className="mt-12 gap-8">
+        <Text className="text-4xl font-display text-surface-foreground dark:text-surface-dark-foreground">
+          CureZ
+        </Text>
+        <Text className="text-2xl font-heading text-surface-foreground/80 dark:text-surface-dark-foreground/80">
+          A mindful companion for young people navigating their wellness journey.
+        </Text>
+        <Image
+          source={{ uri: HERO_URI }}
+          resizeMode="cover"
+          className="w-full h-56 rounded-3xl"
+          accessible
+          accessibilityLabel="Illustration of a person finding calm with the help of a friendly mentor"
+        />
+        <Text className="text-base leading-6 text-surface-foreground/80 dark:text-surface-dark-foreground/80">
+          Bring the full CureZ experience with you. Check in with your mentor, track your progress, and
+          explore exercises designed for your daily routine right from your phone.
+        </Text>
+        <Button title="Begin your journey" onPress={handleBegin} fullWidth className="mt-4" />
+        <View className="bg-surface-muted dark:bg-surface-dark-muted rounded-3xl p-6 gap-4">
+          <Text className="text-lg font-heading text-surface-foreground dark:text-surface-dark-foreground">
+            Unified design system
+          </Text>
+          <Text className="text-base leading-6 text-surface-foreground/70 dark:text-surface-dark-foreground/70">
+            Colors, fonts, and spacing are all powered by the shared Tailwind theme. Update the palette in
+            <Text className="font-semibold"> tailwind.config.js </Text> to refresh the entire app instantly.
+          </Text>
+          <ThemeToggle />
+        </View>
+      </View>
+    </ScrollView>
+  )
+}

--- a/mobile/src/screens/SessionScreen.tsx
+++ b/mobile/src/screens/SessionScreen.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react"
+import {
+  Alert,
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  Text,
+  TextInput,
+  View,
+} from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack"
+import { Button } from "@/components/Button"
+import { Card } from "@/components/Card"
+import { useAuth } from "@/contexts/AuthContext"
+import { useChatSession } from "@/hooks/useChatSession"
+import { RootStackParamList } from "@/navigation/AppNavigator"
+
+export const SessionScreen: React.FC = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
+  const { user } = useAuth()
+  const { messages, sendTextMessage, isSending } = useChatSession(user?.uid)
+  const [text, setText] = useState("")
+
+  const handleSend = async () => {
+    const trimmed = text.trim()
+    if (!trimmed) {
+      return
+    }
+    setText("")
+    try {
+      await sendTextMessage(trimmed)
+    } catch (error) {
+      Alert.alert("Connection issue", "We couldn't deliver your message. Please try again.")
+    }
+  }
+
+  return (
+    <KeyboardAvoidingView
+      className="flex-1 bg-surface dark:bg-surface-dark"
+      behavior={Platform.select({ ios: "padding", android: undefined })}
+    >
+      <View className="flex-1 p-4">
+        <Card className="flex-1">
+          <View className="items-center gap-2 mb-4">
+            <Text className="text-2xl font-heading text-surface-foreground dark:text-surface-dark-foreground">
+              Live mentor session
+            </Text>
+            <Text className="text-sm text-surface-foreground/70 dark:text-surface-dark-foreground/70">
+              We are using the same CureZ intelligence from the web app, optimised for mobile chat.
+            </Text>
+          </View>
+          <FlatList
+            data={messages}
+            keyExtractor={(item) => item.id}
+            contentContainerStyle={{ gap: 12, paddingBottom: 16 }}
+            renderItem={({ item }) => (
+              <View
+                className={`max-w-[85%] px-4 py-3 rounded-3xl ${
+                  item.sender === "user"
+                    ? "self-end bg-brand text-brand-foreground"
+                    : "self-start bg-surface-muted dark:bg-surface-dark-muted text-surface-foreground dark:text-surface-dark-foreground"
+                }`}
+              >
+                <Text className="text-base leading-6">{item.text}</Text>
+              </View>
+            )}
+          />
+          <View className="mt-auto gap-3">
+            <Text className="text-xs text-center text-surface-foreground/60 dark:text-surface-dark-foreground/60">
+              Voice sessions are coming soon to mobile. For now, continue chatting via text and review the
+              summary later on the dashboard.
+            </Text>
+            <View className="flex-row items-center gap-3">
+              <TextInput
+                className="flex-1 rounded-2xl border border-surface-strong dark:border-surface-dark-strong px-4 py-3 text-base text-surface-foreground dark:text-surface-dark-foreground bg-white dark:bg-surface-dark-muted"
+                placeholder="Share how you're feeling..."
+                placeholderTextColor="#94A3B8"
+                value={text}
+                onChangeText={setText}
+                multiline
+                numberOfLines={2}
+                returnKeyType="send"
+                onSubmitEditing={handleSend}
+              />
+              <Button
+                title={isSending ? "Sending..." : "Send"}
+                onPress={handleSend}
+                variant="secondary"
+                className="px-6"
+              />
+            </View>
+            <Button
+              title="End session"
+              variant="ghost"
+              onPress={() => navigation.goBack()}
+              fullWidth
+            />
+          </View>
+        </Card>
+      </View>
+    </KeyboardAvoidingView>
+  )
+}

--- a/mobile/src/services/auth.ts
+++ b/mobile/src/services/auth.ts
@@ -1,0 +1,221 @@
+import { FIREBASE_API_KEY, API_BASE_URL } from "./config"
+
+type FirebaseErrorResponse = {
+  error?: {
+    message?: string
+  }
+}
+
+type SignupResponse = {
+  localId: string
+  email: string
+  idToken: string
+}
+
+type SignInResponse = {
+  localId: string
+  email: string
+  idToken: string
+}
+
+type AccountInfoResponse = {
+  users?: Array<{
+    localId: string
+    email?: string
+    emailVerified?: boolean
+    displayName?: string
+  }>
+}
+
+export type AuthUser = {
+  uid: string
+  email: string
+  name?: string
+  age?: number
+  gender?: string
+  emailVerified?: boolean
+}
+
+export type SignupForm = {
+  email: string
+  password: string
+  name: string
+  age: string
+  gender: string
+}
+
+const ensureApiKey = () => {
+  if (!FIREBASE_API_KEY) {
+    throw new Error(
+      "Firebase web API key is not configured. Set EXPO_PUBLIC_FIREBASE_API_KEY to continue."
+    )
+  }
+  return FIREBASE_API_KEY
+}
+
+const mapFirebaseError = (code?: string) => {
+  switch (code) {
+    case "EMAIL_EXISTS":
+      return "An account with this email already exists."
+    case "INVALID_EMAIL":
+      return "The email address is invalid."
+    case "INVALID_PASSWORD":
+      return "The password is incorrect."
+    case "USER_DISABLED":
+      return "This account has been disabled."
+    case "EMAIL_NOT_FOUND":
+      return "No account found with this email."
+    case "WEAK_PASSWORD":
+    case "WEAK_PASSWORD : Password should be at least 6 characters":
+      return "Password should be at least 6 characters long."
+    default:
+      return code ? code.replace(/_/g, " ").toLowerCase() : undefined
+  }
+}
+
+const firebaseRequest = async <T>(path: string, body: Record<string, unknown>): Promise<T> => {
+  const apiKey = ensureApiKey()
+  const response = await fetch(`https://identitytoolkit.googleapis.com/v1/${path}?key=${apiKey}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+
+  const data = (await response.json()) as T | FirebaseErrorResponse
+
+  if (!response.ok) {
+    const firebaseError = (data as FirebaseErrorResponse)?.error?.message
+    const message = mapFirebaseError(firebaseError)
+    throw new Error(message || "Firebase request failed. Please try again.")
+  }
+
+  return data as T
+}
+
+const syncUserProfile = async (
+  payload: Partial<AuthUser> & { uid: string; email: string; emailVerified?: boolean }
+) => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/signup`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    })
+
+    if (!response.ok) {
+      const data = (await response.json().catch(() => ({}))) as { error?: string }
+      console.warn("Failed to persist user profile:", data.error || response.statusText)
+    }
+  } catch (error) {
+    console.error("Failed to sync user profile:", error)
+  }
+}
+
+export const signup = async (form: SignupForm) => {
+  const signupData = await firebaseRequest<SignupResponse>("accounts:signUp", {
+    email: form.email,
+    password: form.password,
+    returnSecureToken: true,
+  })
+
+  try {
+    await firebaseRequest("accounts:sendOobCode", {
+      requestType: "VERIFY_EMAIL",
+      idToken: signupData.idToken,
+    })
+  } catch (error) {
+    console.error("Failed to send verification email:", error)
+    throw new Error("Failed to send verification email. Please try again.")
+  }
+
+  await syncUserProfile({
+    uid: signupData.localId,
+    email: signupData.email,
+    name: form.name,
+    age: form.age ? Number.parseInt(form.age, 10) : undefined,
+    gender: form.gender || undefined,
+    emailVerified: false,
+  })
+
+  return { uid: signupData.localId, email: signupData.email }
+}
+
+export const login = async (email: string, password: string) => {
+  const signInData = await firebaseRequest<SignInResponse>("accounts:signInWithPassword", {
+    email,
+    password,
+    returnSecureToken: true,
+  })
+
+  const accountInfo = await firebaseRequest<AccountInfoResponse>("accounts:lookup", {
+    idToken: signInData.idToken,
+  })
+
+  const firebaseUser = accountInfo.users?.[0]
+
+  if (!firebaseUser) {
+    throw new Error("Unable to retrieve user information.")
+  }
+
+  if (!firebaseUser.emailVerified) {
+    try {
+      await firebaseRequest("accounts:sendOobCode", {
+        requestType: "VERIFY_EMAIL",
+        idToken: signInData.idToken,
+      })
+    } catch (error) {
+      console.error("Failed to resend verification email:", error)
+    }
+    const error: Error & { code?: string } = new Error(
+      "Email not verified. We sent you another verification link."
+    )
+    error.code = "EMAIL_NOT_VERIFIED"
+    throw error
+  }
+
+  const profile = await getCurrentUser(signInData.localId)
+
+  return {
+    uid: signInData.localId,
+    email: signInData.email,
+    name: profile?.name,
+    age: profile?.age,
+    gender: profile?.gender,
+    emailVerified: firebaseUser.emailVerified,
+  } as AuthUser
+}
+
+export const requestPasswordReset = async (email: string) => {
+  await firebaseRequest("accounts:sendOobCode", {
+    requestType: "PASSWORD_RESET",
+    email,
+  })
+}
+
+export const getCurrentUser = async (uid: string) => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/user/${uid}`)
+    if (!response.ok) {
+      return null
+    }
+    return (await response.json()) as Partial<AuthUser> | null
+  } catch (error) {
+    console.error("Failed to fetch user profile:", error)
+    return null
+  }
+}
+
+export const updateProfile = async (payload: Partial<AuthUser> & { uid: string }) => {
+  const response = await fetch(`${API_BASE_URL}/api/update-profile`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  })
+
+  if (!response.ok) {
+    const data = (await response.json().catch(() => ({}))) as { error?: string }
+    throw new Error(data.error || "Failed to update profile")
+  }
+
+  return (await response.json()) as AuthUser
+}

--- a/mobile/src/services/config.ts
+++ b/mobile/src/services/config.ts
@@ -1,0 +1,11 @@
+const normalizeBaseUrl = (value: string | undefined) => {
+  if (!value) {
+    return undefined
+  }
+  return value.endsWith("/") ? value.slice(0, -1) : value
+}
+
+export const API_BASE_URL =
+  normalizeBaseUrl(process.env.EXPO_PUBLIC_API_BASE_URL) || "http://localhost:3000"
+
+export const FIREBASE_API_KEY = process.env.EXPO_PUBLIC_FIREBASE_API_KEY

--- a/mobile/src/services/session.ts
+++ b/mobile/src/services/session.ts
@@ -1,0 +1,39 @@
+import { API_BASE_URL } from "@/services/config"
+
+export type ChatMessage = {
+  id: string
+  text: string
+  sender: "user" | "assistant"
+  createdAt: string
+}
+
+export type SessionReply = {
+  reply: string
+}
+
+export const sendSessionMessage = async (
+  message: string,
+  options: { userId?: string } = {}
+): Promise<SessionReply> => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/mobile-session`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message, userId: options.userId }),
+    })
+
+    if (response.ok) {
+      const data = (await response.json()) as SessionReply
+      if (data?.reply) {
+        return data
+      }
+    }
+  } catch (error) {
+    console.warn("Falling back to local session response", error)
+  }
+
+  return {
+    reply:
+      "Thank you for sharing. I'm still getting connected to the live mentor service, but I'm here to listen. Try again once your network is ready.",
+  }
+}

--- a/mobile/tailwind.config.js
+++ b/mobile/tailwind.config.js
@@ -1,0 +1,57 @@
+const colors = {
+  brand: {
+    DEFAULT: "#6366F1",
+    foreground: "#F8FAFC",
+    dark: "#4F46E5",
+    "dark-foreground": "#E0E7FF",
+  },
+  accent: {
+    DEFAULT: "#14B8A6",
+    muted: "#99F6E4",
+    dark: "#0F766E",
+  },
+  surface: {
+    DEFAULT: "#FFFFFF",
+    muted: "#F1F5F9",
+    strong: "#E2E8F0",
+    foreground: "#0F172A",
+    dark: "#0B1120",
+    "dark-muted": "#111827",
+    "dark-strong": "#1F2937",
+    "dark-foreground": "#E2E8F0",
+  },
+  feedback: {
+    success: "#22C55E",
+    caution: "#F59E0B",
+    danger: "#EF4444",
+  },
+}
+
+module.exports = {
+  content: ["./App.{js,jsx,ts,tsx}", "./src/**/*.{js,jsx,ts,tsx}"],
+  darkMode: "class",
+  theme: {
+    extend: {
+      colors,
+      fontFamily: {
+        heading: ["Poppins", "System"],
+        body: ["Inter", "System"],
+        display: ["Poppins", "System"],
+      },
+      fontWeight: {
+        "brand-light": "300",
+        "brand-normal": "400",
+        "brand-medium": "500",
+        "brand-semibold": "600",
+        "brand-bold": "700",
+      },
+      borderRadius: {
+        xl: "1.25rem",
+      },
+      boxShadow: {
+        elevated: "0 20px 45px -20px rgba(79, 70, 229, 0.45)",
+      },
+    },
+  },
+  plugins: [],
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold a new Expo-powered React Native app under `mobile/` with navigation, theming, and session screens
- integrate Firebase-based auth helpers and a chat session hook that falls back when the mobile endpoint is offline
- centralize colors, typography, and elevation tokens in `mobile/tailwind.config.js` and document mobile setup in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68f70224bc688323994e0e6cacd8e877